### PR TITLE
Fix Psych compatibility errors for ruby 3.1+

### DIFF
--- a/lib/yaml_extensions.rb
+++ b/lib/yaml_extensions.rb
@@ -31,8 +31,8 @@ class Array
 end
 
 module YamlExtensions
-  def load(*args)
-    super(*args).walk do |h|
+  def load(*args, **kwargs)
+    super(*args, **kwargs).walk do |h|
       h.keys.sort.reverse_each do |key|
         if key =~ /^<<<\d*$/
           h.deep_merge!(h.delete(key)) { |_, this, _| this }


### PR DESCRIPTION
Psych 4 (released with [Ruby 3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/)) replaces all positional arguments on `YAML.load`, except for `content`, with keyword ones.
This PR adjusts the signature of the patched `.load` accordingly and forwards the arguments to `YAML` in the same fashion.
I believe this isn't a breaking change as argument expansion will work as before for projects still using the positional style, so a bump to version 0.2.0 is probably enough.

@branch14 thanks for this gem, got me out of a pickle here. I know it's been a while since you touched the project, but I figured I might as well open a PR in hopes it helps others.